### PR TITLE
fix: use new package to ensure jsonproperties are parsed

### DIFF
--- a/src/Altinn.Dan.Plugin.Trad/Altinn.Dan.Plugin.Trad.csproj
+++ b/src/Altinn.Dan.Plugin.Trad/Altinn.Dan.Plugin.Trad.csproj
@@ -14,7 +14,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
-    <PackageReference Include="NJsonSchema" Version="11.1.0" />
+    <PackageReference Include="NJsonSchema" Version="11.3.2" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.3.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/Altinn.Dan.Plugin.Trad/Metadata.cs
+++ b/src/Altinn.Dan.Plugin.Trad/Metadata.cs
@@ -4,7 +4,7 @@ using Dan.Common.Enums;
 using Dan.Common.Interfaces;
 using Dan.Common.Models;
 using Newtonsoft.Json;
-using NJsonSchema;
+using NJsonSchema.NewtonsoftJson.Generation;
 
 namespace Altinn.Dan.Plugin.Trad
 {
@@ -110,7 +110,7 @@ namespace Altinn.Dan.Plugin.Trad
                         {
                             EvidenceValueName = "default",
                             ValueType = EvidenceValueType.JsonSchema,
-                            JsonSchemaDefintion = JsonSchema.FromType<PersonExternal>().ToJson(Formatting.None),
+                            JsonSchemaDefintion = NewtonsoftJsonSchemaGenerator.FromType<PersonExternal>().ToJson(Formatting.None),
                         }
                     },
                     AuthorizationRequirements = new List<Requirement>
@@ -132,7 +132,7 @@ namespace Altinn.Dan.Plugin.Trad
                         {
                             EvidenceValueName = "default",
                             ValueType = EvidenceValueType.JsonSchema,
-                            JsonSchemaDefintion = JsonSchema.FromType<PersonPrivate>().ToJson(Formatting.None),
+                            JsonSchemaDefintion = NewtonsoftJsonSchemaGenerator.FromType<PersonPrivate>().ToJson(Formatting.None),
                         }
                     },
                     AuthorizationRequirements = new List<Requirement>


### PR DESCRIPTION
### Description
When NJsonSchema was updated to version 11, it turns out it switched from defaulting to Newtonsoft to System.Text.Json
Which is fine, except it did so silently, so it just ignored our Newtonsoft properties. They have a separate package for Newtonsoft support at least, so just swapping to that with this change

### Documentation
- [ ] Doc updated
