### PR TITLE
pinned sha version to workflow

### DIFF
--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -14,7 +14,7 @@ jobs:
     actions: read
     contents: read
     security-events: write
-  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@main
+  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@d08132e852a68b9e10b759cb30e23366219790b0
   with:
     artifact_name: 'dan-plugin-trad' # Can be omitted, defaults to 'artifact'
     function_project_path: 'src/Altinn.Dan.Plugin.Trad'

--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -10,11 +10,7 @@ on:
 
 jobs:
  run:
-  permissions:
-    actions: read
-    contents: read
-    security-events: write
-  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@d08132e852a68b9e10b759cb30e23366219790b0
+  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@e9a1d62778d9d2f4e8c2245027fb2750fd230e0a
   with:
     artifact_name: 'dan-plugin-trad' # Can be omitted, defaults to 'artifact'
     function_project_path: 'src/Altinn.Dan.Plugin.Trad'


### PR DESCRIPTION
### Description
<!--- What and why -->

### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment workflow to pin the external deployment action to a specific release commit, ensuring consistent, repeatable deployments and reducing unexpected changes from upstream updates.
  * No functional or public API changes; this is an infrastructure stability update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->