### PR TITLE
fix: change naming of AdvRegPersonVerifikasjonPrivat to be consistent

### DIFF
--- a/src/Altinn.Dan.Plugin.Trad/Main.cs
+++ b/src/Altinn.Dan.Plugin.Trad/Main.cs
@@ -39,7 +39,7 @@ public class Main
         return await EvidenceSourceResponse.CreateResponse(req, () => GetEvidenceValuesVerifiserAdvokat(evidenceHarvesterRequest));
     }
 
-    [Function("AdvokatverifikasjonPrivat")]
+    [Function("AdvRegPersonVerifikasjonPrivat")]
     public async Task<HttpResponseData> RunAsyncAdvokatverifikasjonPrivat(
         [HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req, 
         FunctionContext context)

--- a/src/Altinn.Dan.Plugin.Trad/Main.cs
+++ b/src/Altinn.Dan.Plugin.Trad/Main.cs
@@ -119,7 +119,7 @@ public class Main
     {
         var res = await _cache.GetAsync(Helpers.GetCacheKeyForSsn(evidenceHarvesterRequest.SubjectParty!.NorwegianSocialSecurityNumber));
 
-        var ecb = new EvidenceBuilder(_metadata, "AdvokatverifikasjonPrivat");
+        var ecb = new EvidenceBuilder(_metadata, "AdvRegPersonVerifikasjonPrivat");
         if (res != null)
         {
             var person = JsonConvert.DeserializeObject<PersonInternal>(Encoding.UTF8.GetString(res));

--- a/src/Altinn.Dan.Plugin.Trad/Metadata.cs
+++ b/src/Altinn.Dan.Plugin.Trad/Metadata.cs
@@ -55,9 +55,13 @@ namespace Altinn.Dan.Plugin.Trad
                 },
                 new()
                 {
-                    EvidenceCodeName = "AdvokatverifikasjonPrivat",
+                    EvidenceCodeName = "AdvRegPersonVerifikasjonPrivat",
                     EvidenceSource = Source,
                     BelongsToServiceContexts = new List<string> { "Advokatregisteret" },
+                    DatasetAliases = [
+                        new DatasetAlias{ ServiceContext = "Advokatregisteret", DatasetAliasName = "AdvRegPersonVerifikasjonPrivat" },
+                        new DatasetAlias{ ServiceContext = "Advokatregisteret", DatasetAliasName = "AdvokatverifikasjonPrivat" }
+                    ],
                     Values = new List<EvidenceValue>
                     {
                         new()


### PR DESCRIPTION
### Description
The private verification endpoint didnt follow the naming standard of the other datasets. Change it to be consistent, and add alias for the old name to make that still usable.

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated naming convention for attorney registration verification service to improve clarity and consistency.
  * Added backward compatibility aliases to ensure existing integrations continue to function without disruption.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->