### PR TITLE
DAN-259: replaced Moq with FakeItEasy

### DIFF
--- a/test/Altinn.Dan.Plugin.Trad.Test/Altinn.Dan.Plugin.Trad.Test.csproj
+++ b/test/Altinn.Dan.Plugin.Trad.Test/Altinn.Dan.Plugin.Trad.Test.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />

--- a/test/Altinn.Dan.Plugin.Trad.Test/ImportRegistryTest.cs
+++ b/test/Altinn.Dan.Plugin.Trad.Test/ImportRegistryTest.cs
@@ -18,21 +18,15 @@ namespace Altinn.Dan.Plugin.Trad.Test
     [TestClass]
     public class ImportRegistryTest
     {
-        private readonly IHttpClientFactory _mockFactory = A.Fake<IHttpClientFactory>();
-        private readonly IConnectionMultiplexer _mockConnectionMultiplexer = A.Fake<IConnectionMultiplexer>();
-        private readonly IDatabase _mockDatabase = A.Fake<IDatabase>();
-        private readonly IOrganizationService _mockOrganizationService = A.Fake<IOrganizationService>();
-        private readonly IMaskinportenService _mockMaskinportenService = A.Fake<IMaskinportenService>();
+        private readonly IHttpClientFactory _fakeHttpFactory = A.Fake<IHttpClientFactory>();
+        private readonly IConnectionMultiplexer _fakeConnectionMultiplexer = A.Fake<IConnectionMultiplexer>();
+        private readonly IOrganizationService _fakeOrganizationService = A.Fake<IOrganizationService>();
         private readonly ILoggerFactory _loggerFactory = new LoggerFactory();
 
         [TestInitialize]
         public void Initialize()
         {
-            A.CallTo(() => _mockFactory.CreateClient(A<string>._)).Returns(MakeFakeClient());
-            A.CallTo(() => _mockDatabase.StringSetAsync(A<RedisKey>._, A<RedisValue>._,
-                A<TimeSpan?>._, A<bool>._, A<When>._, A<CommandFlags>._));
-            A.CallTo(() => _mockConnectionMultiplexer.GetDatabase(A<int>._, A<object?>._))
-                .Returns(_mockDatabase);
+            A.CallTo(() => _fakeHttpFactory.CreateClient(A<string>._)).Returns(MakeFakeClient());
         }
 
         [TestMethod]
@@ -44,11 +38,11 @@ namespace Altinn.Dan.Plugin.Trad.Test
             var options = Options.Create(new ApplicationSettings() { RegistryURL = "http://some_url.blahblah.nope", ApiKey = "secretapikey"});
             var func = new ImportRegistry(
                 _loggerFactory,
-                _mockFactory, 
+                _fakeHttpFactory, 
                 options, 
                 mockCache,
-                _mockConnectionMultiplexer,
-                _mockOrganizationService);
+                _fakeConnectionMultiplexer,
+                _fakeOrganizationService);
 
             // Act
             await func.PerformUpdate();
@@ -59,56 +53,56 @@ namespace Altinn.Dan.Plugin.Trad.Test
 
             // - 100 should have one pracice (500), one authorizedRepresentative (200)
             var person100 = backingStore[Helpers.GetCacheKeyForSsn("100")];
-            Assert.IsTrue(person100.Practices.Count == 1);
-            Assert.IsTrue(person100.Practices[0].AuthorizedRepresentatives.Count == 1);
+            Assert.HasCount(1, person100.Practices);
+            Assert.HasCount(1, person100.Practices[0].AuthorizedRepresentatives);
             Assert.IsNull(person100.Practices[0].IsAnAuthorizedRepresentativeFor);
 
             // - 101 should have two pracices (500, 501), each with two authorizedRepresentatives, three distinct: 200, 201, 202
             var person101 = backingStore[Helpers.GetCacheKeyForSsn("101")];
-            Assert.IsTrue(person101.Practices.Count == 2);
-            Assert.IsTrue(person101.Practices[0].AuthorizedRepresentatives.Count == 2);
+            Assert.HasCount(2, person101.Practices);
+            Assert.HasCount(2, person101.Practices[0].AuthorizedRepresentatives);
             Assert.IsTrue(person101.Practices[0].AuthorizedRepresentatives.Any(x => x.Ssn == "200"));
             Assert.IsTrue(person101.Practices[0].AuthorizedRepresentatives.Any(x => x.Ssn == "201"));
             Assert.IsNull(person101.Practices[0].IsAnAuthorizedRepresentativeFor);
-            Assert.IsTrue(person101.Practices[1].AuthorizedRepresentatives.Count == 2);
+            Assert.HasCount(2, person101.Practices[1].AuthorizedRepresentatives);
             Assert.IsTrue(person101.Practices[1].AuthorizedRepresentatives.Any(x => x.Ssn == "201"));
             Assert.IsTrue(person101.Practices[1].AuthorizedRepresentatives.Any(x => x.Ssn == "202"));
             Assert.IsNull(person101.Practices[1].IsAnAuthorizedRepresentativeFor);
 
             // - 200 should have one practice (500), with two isRepresentativeFor (100, 101)
             var person200 = backingStore[Helpers.GetCacheKeyForSsn("200")];
-            Assert.IsTrue(person200.Practices.Count == 1);
-            Assert.IsTrue(person200.Practices[0].IsAnAuthorizedRepresentativeFor.Count == 2);
+            Assert.HasCount(1, person200.Practices);
+            Assert.HasCount(2, person200.Practices[0].IsAnAuthorizedRepresentativeFor);
             Assert.IsTrue(person200.Practices[0].IsAnAuthorizedRepresentativeFor.Any(x => x.Ssn == "100"));
             Assert.IsTrue(person200.Practices[0].IsAnAuthorizedRepresentativeFor.Any(x => x.Ssn == "101"));
             Assert.IsNull(person200.Practices[0].AuthorizedRepresentatives);
 
             // - 201 should have three practices (500, 501, 502), first with one isRepresentativeFor: (101), second with two isRepresentativeFor: (101, 102), last one with one isRepresentativeFor: (102)
             var person201 = backingStore[Helpers.GetCacheKeyForSsn("201")];
-            Assert.IsTrue(person201.Practices.Count == 3);
-            Assert.IsTrue(person201.Practices[0].IsAnAuthorizedRepresentativeFor.Count == 1);
+            Assert.HasCount(3, person201.Practices);
+            Assert.HasCount(1, person201.Practices[0].IsAnAuthorizedRepresentativeFor);
             Assert.IsTrue(person201.Practices[0].IsAnAuthorizedRepresentativeFor.Any(x => x.Ssn == "101"));
             Assert.IsNull(person201.Practices[0].AuthorizedRepresentatives);
-            Assert.IsTrue(person201.Practices[1].IsAnAuthorizedRepresentativeFor.Count == 2);
+            Assert.HasCount(2, person201.Practices[1].IsAnAuthorizedRepresentativeFor);
             Assert.IsTrue(person201.Practices[1].IsAnAuthorizedRepresentativeFor.Any(x => x.Ssn == "101"));
             Assert.IsTrue(person201.Practices[1].IsAnAuthorizedRepresentativeFor.Any(x => x.Ssn == "102"));
             Assert.IsNull(person201.Practices[1].AuthorizedRepresentatives);
-            Assert.IsTrue(person201.Practices[2].IsAnAuthorizedRepresentativeFor.Count == 1);
+            Assert.HasCount(1, person201.Practices[2].IsAnAuthorizedRepresentativeFor);
             Assert.IsTrue(person201.Practices[2].IsAnAuthorizedRepresentativeFor.Any(x => x.Ssn == "102"));
             Assert.IsNull(person201.Practices[2].AuthorizedRepresentatives);
 
             // - 103 should have one practice (503), with one authorizedRepresentative: (104) who is an advokat
             var person103 = backingStore[Helpers.GetCacheKeyForSsn("103")];
-            Assert.IsTrue(person103.Practices.Count == 1);
-            Assert.IsTrue(person103.Practices[0].AuthorizedRepresentatives.Count == 1);
+            Assert.HasCount(1, person103.Practices);
+            Assert.HasCount(1, person103.Practices[0].AuthorizedRepresentatives);
             Assert.IsTrue(person103.Practices[0].AuthorizedRepresentatives.Any(x => x.Ssn == "104"));
 
             // - 104 should have two practices (503, 504), first with one isRepresentativeFor: (103), second one with one authorizedRepresentative (204)
             var person104 = backingStore[Helpers.GetCacheKeyForSsn("104")];
-            Assert.IsTrue(person104.Practices.Count == 2);
-            Assert.IsTrue(person104.Practices[0].IsAnAuthorizedRepresentativeFor.Count == 1);
+            Assert.HasCount(2, person104.Practices);
+            Assert.HasCount(1, person104.Practices[0].IsAnAuthorizedRepresentativeFor);
             Assert.IsTrue(person104.Practices[0].IsAnAuthorizedRepresentativeFor.Any(x => x.Ssn == "103"));
-            Assert.IsTrue(person104.Practices[1].AuthorizedRepresentatives.Count == 1);
+            Assert.HasCount(1, person104.Practices[1].AuthorizedRepresentatives);
             Assert.IsTrue(person104.Practices[1].AuthorizedRepresentatives.Any(x => x.Ssn == "204"));
 
             // TODO check when both isRepresentativeFor and authorizedRepresentative in same practice

--- a/test/Altinn.Dan.Plugin.Trad.Test/ImportRegistryTest.cs
+++ b/test/Altinn.Dan.Plugin.Trad.Test/ImportRegistryTest.cs
@@ -1,40 +1,38 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Net.Http;
-using Moq;
-using Microsoft.Extensions.Logging;
-using Altinn.Dan.Plugin.Trad.Config;
 using System;
 using System.Linq;
 using System.Net;
-using Moq.Protected;
-using System.Threading.Tasks;
+using System.Net.Http;
 using System.Threading;
-using Altinn.Dan.Plugin.Trad.Services;
-using Dan.Common.Interfaces;
-using Microsoft.Extensions.Options;
-using StackExchange.Redis;
+using System.Threading.Tasks;
 using Altinn.ApiClients.Maskinporten.Interfaces;
+using Altinn.Dan.Plugin.Trad.Config;
+using Altinn.Dan.Plugin.Trad.Services;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StackExchange.Redis;
 
 namespace Altinn.Dan.Plugin.Trad.Test
 {
     [TestClass]
     public class ImportRegistryTest
     {
-        private readonly Mock<IHttpClientFactory> _mockFactory = new();
-        private readonly Mock<IConnectionMultiplexer> _mockConnectionMultiplexer = new();
-        private readonly Mock<IDatabase> _mockDatabase = new();
-        private readonly Mock<IOrganizationService> _mockOrganizationService = new();
-        private readonly Mock<IMaskinportenService> _mockMaskinportenService = new();
+        private readonly IHttpClientFactory _mockFactory = A.Fake<IHttpClientFactory>();
+        private readonly IConnectionMultiplexer _mockConnectionMultiplexer = A.Fake<IConnectionMultiplexer>();
+        private readonly IDatabase _mockDatabase = A.Fake<IDatabase>();
+        private readonly IOrganizationService _mockOrganizationService = A.Fake<IOrganizationService>();
+        private readonly IMaskinportenService _mockMaskinportenService = A.Fake<IMaskinportenService>();
         private readonly ILoggerFactory _loggerFactory = new LoggerFactory();
 
         [TestInitialize]
         public void Initialize()
         {
-            _mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(MakeFakeClient());
-            _mockDatabase.Setup(_ => _.StringSetAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(),
-                It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<When>(), It.IsAny<CommandFlags>()));
-            _mockConnectionMultiplexer.Setup(_ => _.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
-                .Returns(_mockDatabase.Object);
+            A.CallTo(() => _mockFactory.CreateClient(A<string>._)).Returns(MakeFakeClient());
+            A.CallTo(() => _mockDatabase.StringSetAsync(A<RedisKey>._, A<RedisValue>._,
+                A<TimeSpan?>._, A<bool>._, A<When>._, A<CommandFlags>._));
+            A.CallTo(() => _mockConnectionMultiplexer.GetDatabase(A<int>._, A<object?>._))
+                .Returns(_mockDatabase);
         }
 
         [TestMethod]
@@ -46,11 +44,11 @@ namespace Altinn.Dan.Plugin.Trad.Test
             var options = Options.Create(new ApplicationSettings() { RegistryURL = "http://some_url.blahblah.nope", ApiKey = "secretapikey"});
             var func = new ImportRegistry(
                 _loggerFactory,
-                _mockFactory.Object, 
+                _mockFactory, 
                 options, 
                 mockCache,
-                _mockConnectionMultiplexer.Object,
-                _mockOrganizationService.Object);
+                _mockConnectionMultiplexer,
+                _mockOrganizationService);
 
             // Act
             await func.PerformUpdate();
@@ -283,19 +281,27 @@ namespace Altinn.Dan.Plugin.Trad.Test
 
         public static HttpClient GetHttpClientMock(string responseBody = "")
         {
-            var handler = new Mock<HttpMessageHandler>();
+            var handler = new FakeHttpMessageHandler(responseBody);
+            return new HttpClient(handler);
+        }
+    }
+    
+    public class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _responseBody;
 
-            handler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .Returns(Task<HttpResponseMessage>.Factory.StartNew(() =>
-                {
-                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(responseBody) };
-                })).Callback<HttpRequestMessage, CancellationToken>(
-                    (_, _) =>
-                    {
-                    });
+        public FakeHttpMessageHandler(string responseBody = "")
+        {
+            _responseBody = responseBody;
+        }
 
-            return new HttpClient(handler.Object);
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_responseBody)
+            };
+            return Task.FromResult(response);
         }
     }
 }


### PR DESCRIPTION
### Description
<!--- What and why -->

### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test suite to replace the previous mocking framework with a different one for improved maintainability; test doubles and HTTP response mocking were adjusted accordingly while preserving existing test objectives and behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->