### PR TITLE
fix: filter out entries with missing org nr

### DIFF
--- a/src/Altinn.Dan.Plugin.Trad/Altinn.Dan.Plugin.Trad.csproj
+++ b/src/Altinn.Dan.Plugin.Trad/Altinn.Dan.Plugin.Trad.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
-    <PackageReference Include="NJsonSchema" Version="11.6.1" />
+    <PackageReference Include="NJsonSchema" Version="11.6.1" /> 
     <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.6.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Altinn.Dan.Plugin.Trad/Helpers.cs
+++ b/src/Altinn.Dan.Plugin.Trad/Helpers.cs
@@ -96,7 +96,7 @@ public static class Helpers
     {
         return new PracticeExternal
         {
-            OrganizationNumber = practiceInternal.OrganizationNumber,
+            OrganizationNumber = practiceInternal.OrganizationNumber!.Value,
             AuthorizedRepresentatives =
                 MapInternalPersonListToExternal(practiceInternal.AuthorizedRepresentatives, false),
             IsaAuthorizedRepresentativeFor =
@@ -134,7 +134,7 @@ public static class Helpers
         var zipBulkPractice = new ZipBulkPractice
         {
             CompanyNumber = practiceInternal.CompanyNumber,
-            OrganizationNumber = practiceInternal.OrganizationNumber,
+            OrganizationNumber = practiceInternal.OrganizationNumber!.Value,
             AuthorizedRepresentatives =
                 practiceInternal.AuthorizedRepresentatives?
                     .Where(p => p is not null)
@@ -181,7 +181,7 @@ public static class Helpers
         var zipBulkPractice = new ZipBulkPracticePrivate
         {
             CompanyNumber = practiceInternal.CompanyNumber,
-            OrganizationNumber = practiceInternal.OrganizationNumber,
+            OrganizationNumber = practiceInternal.OrganizationNumber!.Value,
             AuthorizedRepresentatives =
                 practiceInternal.AuthorizedRepresentatives?
                     .Where(p => p is not null)
@@ -248,7 +248,7 @@ public static class Helpers
     {
         return new PracticePrivate
         {
-            OrganizationNumber = practiceInternal.OrganizationNumber,
+            OrganizationNumber = practiceInternal.OrganizationNumber!.Value,
             AuthorizedRepresentatives =
                 MapInternalPersonListToPrivate(practiceInternal.AuthorizedRepresentatives, false),
             IsaAuthorizedRepresentativeFor =

--- a/src/Altinn.Dan.Plugin.Trad/ImportRegistry.cs
+++ b/src/Altinn.Dan.Plugin.Trad/ImportRegistry.cs
@@ -130,8 +130,10 @@ public class ImportRegistry(
         {
             var response = JsonConvert.DeserializeObject<List<PersonInternal>>(await result.Content.ReadAsStringAsync()).ToList();
             var missingOrgNumbers = response
-                .Where(p => p.Practices.Any(pr => pr.OrganizationNumber == null))
+                .Where(p => p.Practices is not null && 
+                            p.Practices.Any(pr => pr.OrganizationNumber == null))
                 .Select(p => p.RegistrationNumber)
+                .Distinct()
                 .ToList();
             var trimmedResponse = response
                 .Where(p => !missingOrgNumbers.Contains(p.RegistrationNumber))

--- a/src/Altinn.Dan.Plugin.Trad/ImportRegistry.cs
+++ b/src/Altinn.Dan.Plugin.Trad/ImportRegistry.cs
@@ -128,8 +128,21 @@ public class ImportRegistry(
 
         try
         {
-            var response = JsonConvert.DeserializeObject<List<PersonInternal>>(await result.Content.ReadAsStringAsync());
-            return response;
+            var response = JsonConvert.DeserializeObject<List<PersonInternal>>(await result.Content.ReadAsStringAsync()).ToList();
+            var missingOrgNumbers = response
+                .Where(p => p.Practices.Any(pr => pr.OrganizationNumber == null))
+                .Select(p => p.RegistrationNumber)
+                .ToList();
+            var trimmedResponse = response
+                .Where(p => !missingOrgNumbers.Contains(p.RegistrationNumber))
+                .ToList();
+            if (missingOrgNumbers.Count != 0)
+            {
+                // Just log the erroneous entries, but continue with the import of the rest
+                var errorRegNrs = string.Join(", ", missingOrgNumbers);
+                _logger.LogError("Following registration numbers were unable to be imported due to errors with data values: {regNrs}", errorRegNrs);
+            }
+            return trimmedResponse;
         }
         catch (Exception e) {
             _logger.LogCritical("Unable to decode response from TRAD. {Exception}: {Message}", e.GetType().Name, e.Message);
@@ -189,7 +202,7 @@ public class ImportRegistry(
             if (person.Practices == null) continue;
             foreach (var practice in person.Practices)
             {
-                var orgName = await organizationService.GetOrgName(practice.OrganizationNumber);
+                var orgName = await organizationService.GetOrgName(practice.OrganizationNumber.Value);
                 if (orgName is not null)
                 {
                     practice.OrganizationName = orgName;

--- a/src/Altinn.Dan.Plugin.Trad/Models/PracticeInternal.cs
+++ b/src/Altinn.Dan.Plugin.Trad/Models/PracticeInternal.cs
@@ -11,7 +11,7 @@ namespace Altinn.Dan.Plugin.Trad.Models
 
         [JsonProperty("orgNumber")]
         [JsonConverter(typeof(IntegersWithSpacesConverter))]
-        public int OrganizationNumber { get; set; }
+        public int? OrganizationNumber { get; set; }
 
         [JsonProperty("subOrgNumber", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(IntegersWithSpacesConverter))]


### PR DESCRIPTION
### Description
Source contained entries with missing organisation numbers. While this is not valid data, we want to avoid failing the entire import due to a few erroneous entries. Simple fix to just filter out and log error.

Have ideas for a future implementation of doing more comprehensive parsing of entries, but this is a quick fix that's sufficient for now should we get more cases like this.

Note that in the helpers we don't really check for null value on org number because it's assumed that the ones without value have already been filtered out; they should not be cached, and we only map the cached values to external formats.

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data validation and error handling in the practice registry import process. Registrations with missing organization numbers are now properly identified and filtered out, ensuring only complete and valid practice information is processed and stored in the system, preventing downstream data quality issues and improving overall system reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->